### PR TITLE
fix: 🐛 wrong padding of btn-icon

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -1,5 +1,5 @@
 // btn RWD setting
-.btn {
+.btn:not(.btn-icon) {
   @include media-breakpoint-up(sm) {
     padding-right: 4.5rem;
     padding-left: 4.5rem;


### PR DESCRIPTION
修正btn-icon的padding設定