### PR TITLE
修改變數使input element的padding符合設計稿

### DIFF
--- a/assets/scss/utils/_variables.scss
+++ b/assets/scss/utils/_variables.scss
@@ -64,6 +64,8 @@ $card-border-width: 0;
 // paddings
 $input-btn-padding-y: 1rem;
 $input-btn-padding-x: 4.5rem;
+$input-padding-y: 1rem;
+$input-padding-x: 0.75rem;
 
 // others
 $enable-rfs: false;


### PR DESCRIPTION
先前覆蓋的兩個BS5變數`$input-btn-padding-y`、`$input-btn-padding-x`會導致input element padding也受到影響，因此修改變數：`$input-padding-y`、`$input-padding-x`使input element的padding符合設計稿