### PR TITLE
fix: 🐛 remove default letter-spacing setting for headings

### DIFF
--- a/assets/scss/utils/_utils.scss
+++ b/assets/scss/utils/_utils.scss
@@ -13,13 +13,6 @@
   }
 }
 
-// make all heading classes has 5% letter-sapcing
-@for $i from 1 through 6 {
-  .h#{$i}, .display-#{$i} {
-      letter-spacing: map-get($letter-spacings, h);
-  }
-}
-
 // paragraph typography utitlity classes
 .para-1 {
   font-size: map-get($map: $font-sizes, $key: 6);


### PR DESCRIPTION
移除原先在heading跟display中預設的5%letter-spacing
因為這會導致無法用ls-*覆蓋
**此異動會導致所有套用heading跟display的部分預設letter-spacing消失**