### PR TITLE
fix: 🐛 wrong default color

### DIFF
--- a/assets/scss/utils/_variables.scss
+++ b/assets/scss/utils/_variables.scss
@@ -38,11 +38,11 @@ $secondary: $Secondary-main;
 // $danger:        $red;
 // $light:         $gray-100;
 // $dark:          $gray-900;
-$body-color: #3d3d3d;
+$body-color: $Gray-01;
 $body-bg: $Background-main;
-$body-secondary-color: #3d3d3d;
+$body-secondary-color: $Gray-01;
 $body-secondary-bg: $Background-S1;
-$body-tertiary-color: #3d3d3d;
+$body-tertiary-color: $Gray-01;
 $body-tertiary-bg: $Background-S2;
 
 // Font


### PR DESCRIPTION
預設文字顏色誤植為`#3D3D3D`，應為`$Gray-01:  #2C2C2C`